### PR TITLE
Restrict Kernel Version Check to Below 6.1.39

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,7 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
This commit modifies the kernel version check in the source code to ensure compatibility with kernel versions below 6.1.39. The change was necessary due to the removal of the REGULATORY_IGNORE_STALE_KICKOFF flag in recent kernel versions, which caused compilation issues. The modified check now correctly excludes kernel versions 6.1.39 and above, preventing these issues.

Reference: https://github.com/morrownr/88x2bu-20210702/issues/165#issuecomment-1730133899

Fix #20 
Fix #23